### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -22,7 +22,7 @@ class FactoryTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->program = Mockery::mock(ProgramInterface::class);
     }
@@ -31,7 +31,7 @@ class FactoryTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Output/CLImateTest.php
+++ b/tests/Output/CLImateTest.php
@@ -19,7 +19,7 @@ class CLImateTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->climate = Mockery::mock(\League\CLImate\CLImate::class);
         $this->output = new CLImate($this->climate);
@@ -29,7 +29,7 @@ class CLImateTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Output/FileTest.php
+++ b/tests/Output/FileTest.php
@@ -26,7 +26,7 @@ class FileTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->path = (string) tempnam(sys_get_temp_dir(), "duncan3dc_exec_phpunit_");
 
@@ -38,7 +38,7 @@ class FileTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unlink($this->path);
     }

--- a/tests/Output/HtmlTest.php
+++ b/tests/Output/HtmlTest.php
@@ -16,7 +16,7 @@ class HtmlTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->output = new Html();
     }

--- a/tests/Output/PlainTest.php
+++ b/tests/Output/PlainTest.php
@@ -16,7 +16,7 @@ class PlainTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->output = new Plain();
     }

--- a/tests/Output/SilentTest.php
+++ b/tests/Output/SilentTest.php
@@ -16,7 +16,7 @@ class SilentTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->output = new Silent();
     }

--- a/tests/Output/SymfonyTest.php
+++ b/tests/Output/SymfonyTest.php
@@ -21,7 +21,7 @@ class SymfonyTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/ProgramTest.php
+++ b/tests/ProgramTest.php
@@ -28,7 +28,7 @@ class ProgramTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->output = Mockery::mock(OutputInterface::class);
         $this->program = new Program("ls", $this->output);
@@ -38,7 +38,7 @@ class ProgramTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         CoreFunction::close();
         Mockery::close();

--- a/tests/Programs/ComposerTest.php
+++ b/tests/Programs/ComposerTest.php
@@ -29,7 +29,7 @@ class ComposerTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $output = Mockery::mock(OutputInterface::class);
         $this->composer = new Composer($output);
@@ -43,7 +43,7 @@ class ComposerTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Programs/NodeJsTest.php
+++ b/tests/Programs/NodeJsTest.php
@@ -29,7 +29,7 @@ class NodeJsTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $output = Mockery::mock(OutputInterface::class);
         $this->node = new NodeJs("super-module", $output);
@@ -43,7 +43,7 @@ class NodeJsTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Programs/RubyGemTest.php
+++ b/tests/Programs/RubyGemTest.php
@@ -29,7 +29,7 @@ class RubyGemTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $output = Mockery::mock(OutputInterface::class);
         $this->gem = new RubyGem("super-gem", $output);
@@ -43,7 +43,7 @@ class RubyGemTest extends TestCase
     /**
      * @inheritdoc
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp` and `protected function tearDown` methods.